### PR TITLE
add preview button to form

### DIFF
--- a/app/form/page.tsx
+++ b/app/form/page.tsx
@@ -1,7 +1,5 @@
-import dynamic from "next/dynamic"
+import ValentineForm from "./valentineFormComponent"
 
-const ValentineForm = dynamic(() => import("./valentineFormComponent"), {
-  ssr: false,
-})
-
-export default ValentineForm
+export default function ValentineFormPage () {
+  return <ValentineForm/>
+}

--- a/app/form/valentineFormComponent.tsx
+++ b/app/form/valentineFormComponent.tsx
@@ -3,30 +3,18 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from "@/components/ui/form"
-import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
+import { Form, FormField } from "@/components/ui/form"
 import { Button } from "@/components/ui/button"
 import { useState, useEffect } from "react"
 import { db } from "@/lib/firebase"
 import { collection, addDoc } from "firebase/firestore"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
-import Image from "next/image"
 import { MdHome } from "react-icons/md"
 import mofuFlower from "../../assets/mofu flower crop.png"
 import mofuHeart from "../../assets/mofu heart crop.png"
-import stampFrame from "../../assets/square stamp frame.png"
-import placeholder from "../../assets/placeholder2.jpg"
 import ClickHeartEffect from "@/components/ClickHeartEffect"
 import HeartBackground from "@/components/HeartBackground"
-import heic2any from "heic2any"
 import { logEvent } from "firebase/analytics"
 import { analytics } from "@/lib/firebase"
 import { valentineFormSchema } from "@/schemas/valentineSchema"
@@ -34,6 +22,10 @@ import { compressAndUploadImages } from "@/lib/uploadUtils"
 import { stamps } from "@/lib/constants"
 import ExampleModal from "@/components/ExampleModal"
 import { ValentineProposalProps } from "@/lib/types"
+import { TextInputSection } from "@/components/form/TextInputSection"
+import { StampSelector } from "@/components/form/StampSelector"
+import { ImageUploadField } from "@/components/form/ImageUploadField"
+import { CaptionField } from "@/components/form/CaptionField"
 
 export default function ValentineForm() {
   const [selectedStamp, setSelectedStamp] = useState<string | null>(null)
@@ -73,6 +65,34 @@ export default function ValentineForm() {
   async function handlePreview() {
     const isValid = await form.trigger()
     if (!isValid) {
+      // Scroll to first error field, similar to form.handleSubmit behavior
+      const firstErrorField = Object.keys(form.formState.errors)[0]
+      if (firstErrorField) {
+        // Try multiple selectors to find the error field
+        const selectors = [
+          `[name="${firstErrorField}"]`,
+          `[id="${firstErrorField}"]`,
+          `input[name="${firstErrorField}"]`,
+          `textarea[name="${firstErrorField}"]`,
+        ]
+        
+        let errorElement: Element | null = null
+        for (const selector of selectors) {
+          errorElement = document.querySelector(selector)
+          if (errorElement) break
+        }
+        
+        // If we found an element, scroll to it
+        if (errorElement) {
+          errorElement.scrollIntoView({ behavior: "smooth", block: "center" })
+          // Focus the input if it's focusable
+          if (errorElement instanceof HTMLElement && "focus" in errorElement) {
+            setTimeout(() => {
+              ;(errorElement as HTMLElement).focus()
+            }, 100)
+          }
+        }
+      }
       return
     }
 
@@ -173,113 +193,16 @@ export default function ValentineForm() {
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
             <div className="flex flex-col md:flex-row gap-6">
               <div className="flex-1 bg-[#E5A4A4] rounded-xl p-6 space-y-4">
-                <FormField
+                <TextInputSection control={form.control} />
+                <StampSelector
+                  selectedStamp={selectedStamp}
+                  onStampSelect={(stampId) => {
+                    setSelectedStamp(stampId)
+                    form.setValue("selectedStamp", stampId)
+                  }}
                   control={form.control}
-                  name="senderName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Input
-                          placeholder="Your Name"
-                          {...field}
-                          className="bg-white rounded-xl"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
+                  stamps={stamps}
                 />
-
-                <FormField
-                  control={form.control}
-                  name="recipientName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Input
-                          placeholder="Valentine's Name"
-                          {...field}
-                          className="bg-white rounded-xl"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="message"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Textarea
-                          placeholder="Message"
-                          className="min-h-[200px] bg-white rounded-xl resize-none"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <div className="space-y-2">
-                  <h3
-                    className={`text-white text-xl font-semibold font-fredoka`}
-                  >
-                    Select Stamp
-                  </h3>
-                  <FormField
-                    control={form.control}
-                    name="selectedStamp"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormControl>
-                          <div className="flex gap-4 justify-center">
-                            {stamps.map((stamp) => (
-                              <button
-                                key={stamp.id}
-                                type="button"
-                                onClick={() => {
-                                  setSelectedStamp(stamp.id)
-                                  form.setValue("selectedStamp", stamp.id)
-                                }}
-                                className={`
-                                  w-24 h-24 rounded-lg p-1 transition-all relative
-                                  ${
-                                    selectedStamp === stamp.id
-                                      ? "bg-white"
-                                      : "bg-[#F8E3E3] hover:drop-shadow-lg"
-                                  }
-                                `}
-                              >
-                                <Image
-                                  src={stampFrame}
-                                  alt="Stamp Frame"
-                                  className={`
-                                      w-full h-full object-contain absolute top-0 left-0 scale-110
-                                      ${
-                                        selectedStamp === stamp.id
-                                          ? "brightness-[90%] saturate-[60%] contrast-[120%] invert-[15%] hue-rotate-[50deg]"
-                                          : ""
-                                      }
-                                    `}
-                                />
-
-                                <Image
-                                  src={stamp.src}
-                                  alt={stamp.alt}
-                                  className="w-full h-full object-contain relative z-10"
-                                />
-                              </button>
-                            ))}
-                          </div>
-                        </FormControl>
-                        <FormMessage className="text-center" />
-                      </FormItem>
-                    )}
-                  />
-                </div>
               </div>
 
               <div className="flex-1 bg-[#E5A4A4] rounded-xl p-6">
@@ -289,160 +212,27 @@ export default function ValentineForm() {
                       control={form.control}
                       name="image1"
                       render={({ field: { onChange, ...field } }) => (
-                        <div className="bg-white p-3 pb-0 rounded-lg shadow-md w-full h-full grid grid-rows-[auto_1fr_auto] gap-2">
-                          <FormItem className="bg-[#D9D9D9] w-full aspect-square rounded-md relative overflow-hidden">
-                            <div className="w-full h-full aspect-square">
-                              <Image
-                                src={placeholder}
-                                alt="Upload Background"
-                                fill
-                                className="object-cover"
-                              />
-                              <FormControl>
-                                <div className="text-center w-full h-full relative z-10">
-                                  <Input
-                                    type="file"
-                                    accept="image/jpeg,image/png,image/jpg"
-                                    onChange={async (e) => {
-                                      const file = e.target.files?.[0] || null
-                                      if (!file) return
-
-                                      let previewUrl = null
-
-                                      const validTypes = [
-                                        "image/jpeg",
-                                        "image/png",
-                                        "image/jpg",
-                                      ]
-                                      if (!validTypes.includes(file.type)) {
-                                        form.setError("image1", {
-                                          type: "manual",
-                                          message:
-                                            "File type not supported. Please upload PNG or JPG only.",
-                                        })
-                                        e.target.value = ""
-                                        return
-                                      }
-
-                                      form.clearErrors("image1")
-
-                                      if (
-                                        file.type === "image/heic" ||
-                                        file.name
-                                          .toLowerCase()
-                                          .endsWith(".heic") ||
-                                        file.type === "image/heif" ||
-                                        file.name.toLowerCase().endsWith(".heif")
-                                      ) {
-                                        try {
-                                          const blob = await heic2any({
-                                            blob: file,
-                                            toType: "image/jpeg",
-                                          })
-                                          const convertedFile = new File(
-                                            [blob as Blob],
-                                            file.name.replace(
-                                              /\.(heic|HEIC|heif|HEIF)$/,
-                                              ".jpg",
-                                            ),
-                                            {
-                                              type: "image/jpeg",
-                                            },
-                                          )
-
-                                          previewUrl =
-                                            URL.createObjectURL(convertedFile)
-                                        } catch (error) {
-                                          console.error(
-                                            "HEIC conversion failed:",
-                                            error,
-                                          )
-                                        }
-                                      } else {
-                                        previewUrl = URL.createObjectURL(file)
-                                      }
-
-                                      // Revoke old URL if it exists
-                                      if (preview1) {
-                                        URL.revokeObjectURL(preview1)
-                                      }
-
-                                      onChange(file)
-                                      setPreview1(previewUrl)
-                                    }}
-                                    className="hidden"
-                                    id="image1"
-                                  />
-                                  <label
-                                    htmlFor="image1"
-                                    className="cursor-pointer w-full h-full flex items-center justify-center"
-                                  >
-                                    {preview1 ? (
-                                      <div className="relative w-full h-full">
-                                        <button
-                                          type="button"
-                                          onClick={(e) => {
-                                            e.preventDefault()
-                                            if (preview1) {
-                                              URL.revokeObjectURL(preview1)
-                                            }
-                                            setPreview1(null)
-                                            onChange(null)
-                                          }}
-                                          className="absolute top-1 right-1 bg-[#c7564a] text-white w-6 h-6 rounded-full flex items-center justify-center hover:bg-[#cc0000] transition-colors z-20"
-                                        >
-                                          ×
-                                        </button>
-                                        <img
-                                          src={preview1}
-                                          alt="Preview 1"
-                                          className="w-full h-full object-cover rounded-lg"
-                                        />
-                                      </div>
-                                    ) : (
-                                      <div className="flex items-center justify-center h-40 text-gray-500">
-                                      </div>
-                                    )}
-                                  </label>
-                                </div>
-                              </FormControl>
-                            </div>
-                            <FormMessage />
-                          </FormItem>
-                          <div className="flex items-center justify-center">
-                            <span className="text-gray-400 text-sm text-center">
+                        <ImageUploadField
+                          name="image1"
+                          label={
+                            <>
                               Photo 1 <br className="md:hidden" /> Upload
-                            </span>
-                          </div>
-                        </div>
+                            </>
+                          }
+                          preview={preview1}
+                          onPreviewChange={setPreview1}
+                          form={form}
+                          onChange={onChange}
+                        />
                       )}
                     />
 
-                    <FormField
-                      control={form.control}
+                    <CaptionField
                       name="caption1"
-                      render={({ field }) => (
-                        <FormItem className="rounded-xl overflow-hidden flex flex-col h-full space-y-0">
-                          <div className="bg-[#edd9d9] flex justify-center items-center h-[100px] rounded-t-xl">
-                            <Image
-                              src={mofuFlower}
-                              alt="Mofu Flower"
-                              width={130}
-                              height={130}
-                              className="object-contain mt-4"
-                            />
-                          </div>
-                          <div className="bg-white p-4 border-8 border-[#fff4f4] rounded-b-xl flex-1">
-                            <FormControl>
-                              <Textarea
                                 placeholder="Photo 1 Caption"
-                                {...field}
-                                className="bg-transparent border-none text-sm md:text-sm min-h-[4rem] max-h-[4rem] overflow-y-auto resize-none p-0"
-                              />
-                            </FormControl>
-                          </div>
-                        </FormItem>
-                      )}
+                      decorativeImage={mofuFlower}
+                      imageAlt="Mofu Flower"
+                      control={form.control}
                     />
                   </div>
                   {form.formState.errors.caption1 && (
@@ -452,163 +242,30 @@ export default function ValentineForm() {
                   )}
 
                   <div className="grid grid-cols-2 gap-4">
-                    <FormField
-                      control={form.control}
+                    <CaptionField
                       name="caption2"
-                      render={({ field }) => (
-                        <FormItem className="rounded-xl overflow-hidden flex flex-col space-y-0">
-                          <div className="bg-[#edd9d9] flex justify-center items-center h-[100px] rounded-t-xl">
-                            <Image
-                              src={mofuHeart}
-                              alt="Mofu Heart"
-                              width={130}
-                              height={130}
-                              className="object-cover mt-4"
-                            />
-                          </div>
-                          <div className="bg-white p-4 border-8 border-[#fff4f4] rounded-b-xl flex-1">
-                            <FormControl>
-                              <Textarea
                                 placeholder="Photo 2 Caption"
-                                {...field}
-                                className="bg-transparent border-none text-sm min-h-[4rem] max-h-[4rem] overflow-y-auto resize-none p-0"
-                              />
-                            </FormControl>
-                          </div>
-                        </FormItem>
-                      )}
+                      decorativeImage={mofuHeart}
+                      imageAlt="Mofu Heart"
+                      control={form.control}
                     />
 
                     <FormField
                       control={form.control}
                       name="image2"
                       render={({ field: { onChange, ...field } }) => (
-                        <div className="bg-white p-3 pb-0 rounded-lg shadow-md w-full h-full grid grid-rows-[auto_1fr_auto] gap-2">
-                          <FormItem className="bg-[#D9D9D9] w-full aspect-square rounded-md relative overflow-hidden">
-                            <div className="w-full h-full aspect-square">
-                              <Image
-                                src={placeholder}
-                                alt="Upload Background"
-                                fill
-                                className="object-cover"
-                              />
-                              <FormControl>
-                                <div className="text-center w-full h-full relative z-10">
-                                  <Input
-                                    type="file"
-                                    accept="image/jpeg,image/png,image/jpg"
-                                    onChange={async (e) => {
-                                      const file = e.target.files?.[0] || null
-                                      if (!file) return
-
-                                      let previewUrl = null
-
-                                      const validTypes = [
-                                        "image/jpeg",
-                                        "image/png",
-                                        "image/jpg",
-                                      ]
-                                      if (!validTypes.includes(file.type)) {
-                                        form.setError("image2", {
-                                          type: "manual",
-                                          message:
-                                            "File type not supported. Please upload PNG or JPG only.",
-                                        })
-                                        e.target.value = ""
-                                        return
-                                      }
-
-                                      form.clearErrors("image2")
-
-                                      if (
-                                        file.type === "image/heic" ||
-                                        file.name
-                                          .toLowerCase()
-                                          .endsWith(".heic") ||
-                                        file.type === "image/heif" ||
-                                        file.name.toLowerCase().endsWith(".heif")
-                                      ) {
-                                        try {
-                                          const blob = await heic2any({
-                                            blob: file,
-                                            toType: "image/jpeg",
-                                          })
-                                          const convertedFile = new File(
-                                            [blob as Blob],
-                                            file.name.replace(
-                                              /\.(heic|HEIC|heif|HEIF)$/,
-                                              ".jpg",
-                                            ),
-                                            {
-                                              type: "image/jpeg",
-                                            },
-                                          )
-
-                                          previewUrl =
-                                            URL.createObjectURL(convertedFile)
-                                        } catch (error) {
-                                          console.error(
-                                            "HEIC conversion failed:",
-                                            error,
-                                          )
-                                        }
-                                      } else {
-                                        previewUrl = URL.createObjectURL(file)
-                                      }
-
-                                      // Revoke old URL if it exists
-                                      if (preview2) {
-                                        URL.revokeObjectURL(preview2)
-                                      }
-
-                                      onChange(file)
-                                      setPreview2(previewUrl)
-                                    }}
-                                    className="hidden"
-                                    id="image2"
-                                  />
-                                  <label
-                                    htmlFor="image2"
-                                    className="cursor-pointer w-full h-full flex items-center justify-center"
-                                  >
-                                    {preview2 ? (
-                                      <div className="relative w-full h-full aspect-square">
-                                        <button
-                                          type="button"
-                                          onClick={(e) => {
-                                            e.preventDefault()
-                                            if (preview2) {
-                                              URL.revokeObjectURL(preview2)
-                                            }
-                                            setPreview2(null)
-                                            onChange(null)
-                                          }}
-                                          className="absolute top-1 right-1 bg-[#c7564a] text-white w-6 h-6 rounded-full flex items-center justify-center hover:bg-[#cc0000] transition-colors z-20"
-                                        >
-                                          ×
-                                        </button>
-                                        <img
-                                          src={preview2}
-                                          alt="Preview 2"
-                                          className="w-full h-full object-cover rounded-lg"
-                                        />
-                                      </div>
-                                    ) : (
-                                      <div className="flex items-center justify-center h-40 text-gray-500">
-                                      </div>
-                                    )}
-                                  </label>
-                                </div>
-                              </FormControl>
-                            </div>
-                            <FormMessage />
-                          </FormItem>
-                          <div className="flex items-center justify-center">
-                            <span className="text-gray-400 text-sm text-center">
+                        <ImageUploadField
+                          name="image2"
+                          label={
+                            <>
                               Photo 2 <br className="md:hidden" /> Upload
-                            </span>
-                          </div>
-                        </div>
+                            </>
+                          }
+                          preview={preview2}
+                          onPreviewChange={setPreview2}
+                          form={form}
+                          onChange={onChange}
+                        />
                       )}
                     />
                   </div>
@@ -621,18 +278,18 @@ export default function ValentineForm() {
               </div>
             </div>
 
-            <div className="flex justify-center gap-4 pb-6 md:pb-0">
+            <div className="flex justify-center gap-6 pb-6 md:pb-0">
               <Button
                 type="button"
                 onClick={handlePreview}
-                className={`bg-[#E5A4A4] hover:bg-[#d98f8f] text-white text-xl px-8 py-2 rounded-3xl h-[60px] font-fredoka`}
+                className={`bg-[#E5A4A4] hover:bg-[#d98f8f] text-white text-xl py-2 rounded-3xl h-[60px] font-fredoka w-[150px]`}
                 disabled={loading}
               >
                 Preview
               </Button>
               <Button
                 type="submit"
-                className={`bg-[#E5A4A4] hover:bg-[#d98f8f] text-white text-xl px-8 py-2 rounded-3xl h-[60px] font-fredoka`}
+                className={`bg-[#E5A4A4] hover:bg-[#d98f8f] text-white text-xl px-8 py-2 rounded-3xl h-[60px] font-fredoka w-[150px]`}
                 disabled={loading}
               >
                 {loading ? "Submitting..." : "Generate"}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { fontFredoka, fontPoppins, fontNanumPen } from "@/lib/fonts"
 
 export const metadata: Metadata = {
   title: "Valentine Proposal",
-  description: "Be my valentine",
+  description: "Will you be my valentine?",
   icons: {
     icon: "/favicon.ico",
   },

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -6,6 +6,7 @@ import ClickHeartEffect from "@/components/ClickHeartEffect"
 import SuccessClient from "@/components/SuccessClient"
 import pcBg from "@/assets/mofu yay pc.png"
 import mobileBg from "@/assets/mofu yay mobile longer.png"
+import HomeButton from "@/components/HomeButton"
 
 interface PageProps {
   searchParams: { [key: string]: string | string[] | undefined }
@@ -20,13 +21,7 @@ export default function SuccessPage({ searchParams }: PageProps) {
     <div className="h-svh relative bg-[#ffeded] overflow-hidden">
       <HeartBackground />
       <ClickHeartEffect />
-
-      <Link
-        href="/"
-        className="absolute top-5 left-5 z-20 text-[#d98f8f] hover:text-[#b35151] transition-colors"
-      >
-        <MdHome className="w-[4svh] h-[4svh] md:w-[40px] md:h-[40px]" />
-      </Link>
+      <HomeButton />
 
       <div className="relative z-10 mt-[5svh] md:mt-[80px] md:ml-[5vw] text-center md:text-center md:w-[46vw]">
         <h1 className="text-[14vw] leading-[1] md:text-8xl py-1 font-bold text-[#d98f8f] mb-[4svh] md:mb-[4svh] font-fredoka">

--- a/components/ExampleModal.tsx
+++ b/components/ExampleModal.tsx
@@ -4,16 +4,27 @@ import { motion, AnimatePresence } from "framer-motion"
 import { X, Minus, Maximize2, Minimize2, RotateCw, Search } from "lucide-react"
 import ValentineProposal from "@/components/CardTemplate"
 import { useState } from "react"
+import { ValentineProposalProps } from "@/lib/types"
 
 interface ExampleModalProps {
   isOpen: boolean
   onClose: () => void
+  url?: string
+  isClickable?: boolean
+  valentineData?: Partial<Omit<ValentineProposalProps, "showClickHeartEffect">>
 }
 
-export default function ExampleModal({ isOpen, onClose }: ExampleModalProps) {
+export default function ExampleModal({ 
+  isOpen, 
+  onClose, 
+  url,
+  isClickable = true,
+  valentineData 
+}: ExampleModalProps) {
   const [isMaximized, setIsMaximized] = useState(false)
   const [key, setKey] = useState(0)
-  const mockUrl = "https://www.valentineproposal.com/example"
+  const mockUrl = url || "https://www.valentineproposal.com/example"
+  const isCustomPreview = valentineData !== undefined
 
   const handleReload = () => {
     setKey(prev => prev + 1)
@@ -48,13 +59,19 @@ export default function ExampleModal({ isOpen, onClose }: ExampleModalProps) {
                 <RotateCw size={18} />
               </button>
 
-              <div className="flex-1 flex items-center max-w-2xl mx-4 bg-[#c27e7e] rounded-md px-3 h-7 cursor-pointer group"
-                   onClick={() => window.open(mockUrl, '_blank')}>
+              <div 
+                className={`flex-1 flex items-center max-w-2xl mx-4 bg-[#c27e7e] rounded-md px-3 h-7 ${
+                  isClickable ? 'cursor-pointer group' : 'cursor-default'
+                }`}
+                onClick={isClickable ? () => window.open(mockUrl, '_blank') : undefined}
+              >
                 <Search size={14} className="text-white/70 mr-2" />
                 <input 
                   readOnly
                   value={mockUrl}
-                  className="bg-transparent text-sm text-white w-full outline-none cursor-pointer group-hover:text-pink-200"
+                  className={`bg-transparent text-sm text-white w-full outline-none ${
+                    isClickable ? 'cursor-pointer group-hover:text-pink-200' : 'cursor-default'
+                  }`}
                 />
               </div>
 
@@ -77,16 +94,31 @@ export default function ExampleModal({ isOpen, onClose }: ExampleModalProps) {
                   ? 'scale-100' 
                   : 'scale-[0.8] md:scale-[0.9]'
               } transition-transform`}>
-                <ValentineProposal
-                  imgUrl="/chaewon_first_date.jpeg"
-                  imgCaption="Our first date"
-                  imgUrl2="/meal.jpg"
-                  imgCaption2="Your favorite meal"
-                  valentineName="Chaewon"
-                  senderName="Jordan"
-                  message="I've made reservations at Nobu for Friday. I'll see you at 7:30 then, it's gonna be great!"
-                  showClickHeartEffect={false}
-                />
+                {isCustomPreview ? (
+                  <ValentineProposal
+                    imgUrl={valentineData?.imgUrl ?? ""}
+                    imgCaption={valentineData?.imgCaption ?? ""}
+                    imgUrl2={valentineData?.imgUrl2 ?? ""}
+                    imgCaption2={valentineData?.imgCaption2 ?? ""}
+                    valentineName={valentineData?.valentineName ?? ""}
+                    senderName={valentineData?.senderName ?? ""}
+                    message={valentineData?.message ?? ""}
+                    selectedStamp={valentineData?.selectedStamp ?? "stamp1"}
+                    showClickHeartEffect={false}
+                  />
+                ) : (
+                  <ValentineProposal
+                    imgUrl="/chaewon_first_date.jpeg"
+                    imgCaption="Our first date"
+                    imgUrl2="/meal.jpg"
+                    imgCaption2="Your favorite meal"
+                    valentineName="Chaewon"
+                    senderName="Jordan"
+                    message="I've made reservations at Nobu for Friday. I'll see you at 7:30 then, it's gonna be great!"
+                    selectedStamp="stamp1"
+                    showClickHeartEffect={false}
+                  />
+                )}
               </div>
             </div>
           </motion.div>

--- a/components/ExampleModal.tsx
+++ b/components/ExampleModal.tsx
@@ -11,6 +11,7 @@ interface ExampleModalProps {
   onClose: () => void
   url?: string
   isClickable?: boolean
+  isPreviewMode? : boolean
   valentineData?: Partial<Omit<ValentineProposalProps, "showClickHeartEffect">>
 }
 
@@ -19,12 +20,12 @@ export default function ExampleModal({
   onClose, 
   url,
   isClickable = true,
+  isPreviewMode = false,
   valentineData 
 }: ExampleModalProps) {
   const [isMaximized, setIsMaximized] = useState(false)
   const [key, setKey] = useState(0)
   const mockUrl = url || "https://www.valentineproposal.com/example"
-  const isCustomPreview = valentineData !== undefined
 
   const handleReload = () => {
     setKey(prev => prev + 1)
@@ -94,7 +95,7 @@ export default function ExampleModal({
                   ? 'scale-100' 
                   : 'scale-[0.8] md:scale-[0.9]'
               } transition-transform`}>
-                {isCustomPreview ? (
+                {isPreviewMode ? (
                   <ValentineProposal
                     imgUrl={valentineData?.imgUrl ?? ""}
                     imgCaption={valentineData?.imgCaption ?? ""}

--- a/components/HomeButton.tsx
+++ b/components/HomeButton.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link"
+import { MdHome } from "react-icons/md"
+
+export default function HomeButton() {
+  return (
+    <>
+      <Link
+        href="/"
+        className="absolute top-5 left-5 z-20 text-[#d98f8f] hover:text-[#b35151] transition-colors"
+      >
+        <MdHome className="w-[4svh] h-[4svh] md:w-[40px] md:h-[40px]" />
+      </Link>
+    </>
+  )
+}

--- a/components/form/CaptionField.tsx
+++ b/components/form/CaptionField.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { Control } from "react-hook-form"
+import Image, { StaticImageData } from "next/image"
+import { FormControl, FormField, FormItem } from "@/components/ui/form"
+import { Textarea } from "@/components/ui/textarea"
+
+interface CaptionFieldProps {
+  name: string
+  placeholder: string
+  decorativeImage: StaticImageData
+  imageAlt: string
+  control: Control<any>
+}
+
+export function CaptionField({
+  name,
+  placeholder,
+  decorativeImage,
+  imageAlt,
+  control,
+}: CaptionFieldProps) {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className="rounded-xl overflow-hidden flex flex-col h-full space-y-0">
+          <div className="bg-[#edd9d9] flex justify-center items-center h-[100px] rounded-t-xl">
+            <Image
+              src={decorativeImage}
+              alt={imageAlt}
+              width={130}
+              height={130}
+              className="object-contain mt-4"
+            />
+          </div>
+          <div className="bg-white p-4 border-8 border-[#fff4f4] rounded-b-xl flex-1">
+            <FormControl>
+              <Textarea
+                placeholder={placeholder}
+                {...field}
+                className="bg-transparent border-none text-sm md:text-sm min-h-[4rem] max-h-[4rem] overflow-y-auto resize-none p-0"
+              />
+            </FormControl>
+          </div>
+        </FormItem>
+      )}
+    />
+  )
+}

--- a/components/form/ImageUploadField.tsx
+++ b/components/form/ImageUploadField.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import { UseFormReturn } from "react-hook-form"
+import Image from "next/image"
+import { FormControl, FormItem, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { useImageFileHandler } from "@/hooks/useImageFileHandler"
+import placeholder from "@/assets/placeholder2.jpg"
+
+interface ImageUploadFieldProps {
+  name: string
+  label: string | React.ReactNode
+  preview: string | null
+  onPreviewChange: (url: string | null) => void
+  form: UseFormReturn<any>
+  onChange: (file: File | null) => void
+}
+
+export function ImageUploadField({
+  name,
+  label,
+  preview,
+  onPreviewChange,
+  form,
+  onChange,
+}: ImageUploadFieldProps) {
+  const { handleImageChange } = useImageFileHandler({
+    form,
+    fieldName: name,
+    onPreviewChange,
+    currentPreview: preview,
+  })
+
+  return (
+    <div className="bg-white p-3 pb-0 rounded-lg shadow-md w-full h-full grid grid-rows-[auto_1fr_auto] gap-2">
+      <FormItem className="bg-[#D9D9D9] w-full aspect-square rounded-md relative overflow-hidden">
+        <div className="w-full h-full aspect-square">
+          <Image
+            src={placeholder}
+            alt="Upload Background"
+            fill
+            className="object-cover"
+          />
+          <FormControl>
+            <div className="text-center w-full h-full relative z-10">
+              <Input
+                type="file"
+                accept="image/jpeg,image/png,image/jpg"
+                onChange={async (e) => {
+                  const file = e.target.files?.[0] || null
+                  await handleImageChange(file, onChange, e.target)
+                }}
+                className="hidden"
+                id={name}
+              />
+              <label
+                htmlFor={name}
+                className="cursor-pointer w-full h-full flex items-center justify-center"
+              >
+                {preview ? (
+                  <div className="relative w-full h-full">
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault()
+                        if (preview) {
+                          URL.revokeObjectURL(preview)
+                        }
+                        onPreviewChange(null)
+                        onChange(null)
+                      }}
+                      className="absolute top-1 right-1 bg-[#c7564a] text-white w-6 h-6 rounded-full flex items-center justify-center hover:bg-[#cc0000] transition-colors z-20"
+                    >
+                      ×
+                    </button>
+                    <img
+                      src={preview}
+                      alt={`Preview ${name}`}
+                      className="w-full h-full object-cover rounded-lg"
+                    />
+                  </div>
+                ) : (
+                  <div className="flex items-center justify-center h-40 text-gray-500"></div>
+                )}
+              </label>
+            </div>
+          </FormControl>
+        </div>
+        <FormMessage />
+      </FormItem>
+      <div className="flex items-center justify-center">
+        <span className="text-gray-400 text-sm text-center">
+          {label}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/components/form/StampSelector.tsx
+++ b/components/form/StampSelector.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { Control } from "react-hook-form"
+import Image, { StaticImageData } from "next/image"
+import { FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form"
+import stampFrame from "@/assets/square stamp frame.png"
+
+interface StampOption {
+  id: string
+  src: StaticImageData
+  alt: string
+}
+
+interface StampSelectorProps {
+  selectedStamp: string | null
+  onStampSelect: (stampId: string) => void
+  control: Control<any>
+  stamps: StampOption[]
+}
+
+export function StampSelector({
+  selectedStamp,
+  onStampSelect,
+  control,
+  stamps,
+}: StampSelectorProps) {
+  return (
+    <div className="space-y-2">
+      <h3 className={`text-white text-xl font-semibold font-fredoka`}>
+        Select Stamp
+      </h3>
+      <FormField
+        control={control}
+        name="selectedStamp"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <div className="flex gap-4 justify-center">
+                {stamps.map((stamp) => (
+                  <button
+                    key={stamp.id}
+                    type="button"
+                    onClick={() => {
+                      onStampSelect(stamp.id)
+                      field.onChange(stamp.id)
+                    }}
+                    className={`
+                      w-24 h-24 rounded-lg p-1 transition-all relative
+                      ${
+                        selectedStamp === stamp.id
+                          ? "bg-white"
+                          : "bg-[#F8E3E3] hover:drop-shadow-lg"
+                      }
+                    `}
+                  >
+                    <Image
+                      src={stampFrame}
+                      alt="Stamp Frame"
+                      className={`
+                          w-full h-full object-contain absolute top-0 left-0 scale-110
+                          ${
+                            selectedStamp === stamp.id
+                              ? "brightness-[90%] saturate-[60%] contrast-[120%] invert-[15%] hue-rotate-[50deg]"
+                              : ""
+                          }
+                        `}
+                    />
+
+                    <Image
+                      src={stamp.src}
+                      alt={stamp.alt}
+                      className="w-full h-full object-contain relative z-10"
+                    />
+                  </button>
+                ))}
+              </div>
+            </FormControl>
+            <FormMessage className="text-center" />
+          </FormItem>
+        )}
+      />
+    </div>
+  )
+}

--- a/components/form/TextInputSection.tsx
+++ b/components/form/TextInputSection.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { Control } from "react-hook-form"
+import { FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+interface TextInputSectionProps {
+  control: Control<any>
+}
+
+export function TextInputSection({ control }: TextInputSectionProps) {
+  return (
+    <>
+      <FormField
+        control={control}
+        name="senderName"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <Input
+                placeholder="Your Name"
+                {...field}
+                className="bg-white rounded-xl"
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="recipientName"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <Input
+                placeholder="Valentine's Name"
+                {...field}
+                className="bg-white rounded-xl"
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="message"
+        render={({ field }) => (
+          <FormItem>
+            <FormControl>
+              <Textarea
+                placeholder="Message"
+                className="min-h-[200px] bg-white rounded-xl resize-none"
+                {...field}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  )
+}

--- a/hooks/useImageFileHandler.ts
+++ b/hooks/useImageFileHandler.ts
@@ -1,0 +1,77 @@
+import { UseFormReturn } from "react-hook-form"
+import heic2any from "heic2any"
+
+interface UseImageFileHandlerOptions {
+  form: UseFormReturn<any>
+  fieldName: string
+  onPreviewChange: (url: string | null) => void
+  currentPreview: string | null
+}
+
+export function useImageFileHandler({
+  form,
+  fieldName,
+  onPreviewChange,
+  currentPreview,
+}: UseImageFileHandlerOptions) {
+  const handleImageChange = async (
+    file: File | null,
+    onChange: (file: File | null) => void,
+    inputElement?: HTMLInputElement,
+  ) => {
+    if (!file) return
+
+    let previewUrl: string | null = null
+
+    const validTypes = ["image/jpeg", "image/png", "image/jpg"]
+    if (!validTypes.includes(file.type)) {
+      form.setError(fieldName, {
+        type: "manual",
+        message: "File type not supported. Please upload PNG or JPG only.",
+      })
+      if (inputElement) {
+        inputElement.value = ""
+      }
+      return
+    }
+
+    form.clearErrors(fieldName)
+
+    if (
+      file.type === "image/heic" ||
+      file.name.toLowerCase().endsWith(".heic") ||
+      file.type === "image/heif" ||
+      file.name.toLowerCase().endsWith(".heif")
+    ) {
+      try {
+        const blob = await heic2any({
+          blob: file,
+          toType: "image/jpeg",
+        })
+        const convertedFile = new File(
+          [blob as Blob],
+          file.name.replace(/\.(heic|HEIC|heif|HEIF)$/, ".jpg"),
+          {
+            type: "image/jpeg",
+          },
+        )
+
+        previewUrl = URL.createObjectURL(convertedFile)
+      } catch (error) {
+        console.error("HEIC conversion failed:", error)
+      }
+    } else {
+      previewUrl = URL.createObjectURL(file)
+    }
+
+    // Revoke old URL if it exists
+    if (currentPreview) {
+      URL.revokeObjectURL(currentPreview)
+    }
+
+    onChange(file)
+    onPreviewChange(previewUrl)
+  }
+
+  return { handleImageChange }
+}

--- a/hooks/useImageFileHandler.ts
+++ b/hooks/useImageFileHandler.ts
@@ -1,5 +1,4 @@
 import { UseFormReturn } from "react-hook-form"
-import heic2any from "heic2any"
 
 interface UseImageFileHandlerOptions {
   form: UseFormReturn<any>
@@ -8,12 +7,20 @@ interface UseImageFileHandlerOptions {
   currentPreview: string | null
 }
 
+interface UseImageFileHandlerReturn {
+  handleImageChange: (
+    file: File | null,
+    onChange: (file: File | null) => void,
+    inputElement?: HTMLInputElement | (EventTarget & HTMLInputElement),
+  ) => Promise<void>
+}
+
 export function useImageFileHandler({
   form,
   fieldName,
   onPreviewChange,
   currentPreview,
-}: UseImageFileHandlerOptions) {
+}: UseImageFileHandlerOptions): UseImageFileHandlerReturn {
   const handleImageChange = async (
     file: File | null,
     onChange: (file: File | null) => void,
@@ -44,6 +51,8 @@ export function useImageFileHandler({
       file.name.toLowerCase().endsWith(".heif")
     ) {
       try {
+        const heic2any = (await import("heic2any")).default
+
         const blob = await heic2any({
           blob: file,
           toType: "image/jpeg",

--- a/schemas/valentineSchema.ts
+++ b/schemas/valentineSchema.ts
@@ -19,9 +19,8 @@ export const valentineFormSchema = z
     },
   )
   .refine((data) => (data.caption1 ? !!data.image1 : true), {
-    message:
-      "You wrote a caption for your first image but forgot to upload the image!",
-    path: ["image1"],
+    message: "You forgot to add a photo for your first caption!",
+    path: ["caption1"],
   })
   .refine(
     (data) => (data.image2 ? (data.caption2 ?? "").trim().length > 0 : true),
@@ -31,9 +30,8 @@ export const valentineFormSchema = z
     },
   )
   .refine((data) => (data.caption2 ? !!data.image2 : true), {
-    message:
-      "You wrote a caption for your second image but forgot to upload the image!",
-    path: ["image2"],
+    message: "You forgot to add a photo for your second caption!",
+    path: ["caption2"],
   })
 
 export type ValentineFormValues = z.infer<typeof valentineFormSchema>


### PR DESCRIPTION
# Add Preview Button & Refactor Valentine Form Component

## Summary
Adds preview functionality to the valentine form and refactors the component to eliminate code duplication, reducing the main file from 657 to 314 lines (52% reduction).

## Key Changes

### New Features
- ✨ Preview button to preview valentine card before submitting (logic extracted from example modal)
- ✨ Auto-scroll to first error field on preview click (matches Generate button behavior)

### Refactoring
- 🔧 Extracted 5 reusable components (`ImageUploadField`, `CaptionField`, `StampSelector`, `TextInputSection`, `useImageFileHandler`)
- 🔧 Eliminated ~200 lines of duplicated image upload logic
- 🔧 Improved code organization and maintainability

### Improvements
- 🐛 Added URL cleanup on unmount (prevents memory leaks)
- 🐛 Improved form validation detection for caption present but photo missing case
- 🎨 Improved image removal button positioning consistency (photo upload 1 x button didn't have proper top padding)
- 📝 Enhanced error message display (caption error messages used to appear only under the caption container, causing the photo container to stretch vertically. now it appears under the entire photo + caption row to remove unwanted stretching)

## Files Changed
- `app/form/valentineFormComponent.tsx` - Refactored (657 → 314 lines)
- `components/form/*` - 4 new reusable components
- `hooks/useImageFileHandler.ts` - New custom hook
- `components/ExampleModal.tsx` - Enhanced for preview support
- `schemas/valentineSchema.ts` - Minor updates

## Testing
- [ ] ensure the to chaewon example modal functions exactly the same as before
- [ ] try out all permutations of invalid form input before clicking the generate or preview buttons
- [ ] click the preview button with all permutations of valid input (0, 1, or 2 photos with captions), test the preview modal
- [ ] change the data after clicking preview once, click it again and ensure data is updated. try several times in a row.
- [ ] click the generate button with all permutations of valid input, ensure sites are generated properly
- [ ] (post deployment) test on mobile device, ensure upload from photo library works for image